### PR TITLE
Update MySqlConnector to 1.0

### DIFF
--- a/src/NHibernate.Driver.MySqlConnector/MySqlConnectorDriver.cs
+++ b/src/NHibernate.Driver.MySqlConnector/MySqlConnectorDriver.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Data.Common;
 
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 using NHibernate.AdoNet;
 using NHibernate.Engine;

--- a/src/NHibernate.Driver.MySqlConnector/NHibernate.Driver.MySqlConnector.csproj
+++ b/src/NHibernate.Driver.MySqlConnector/NHibernate.Driver.MySqlConnector.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
         <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MySqlConnector" Version="0.63.0" />
+    <PackageReference Include="MySqlConnector" Version="1.0.0-beta.1" />
     <PackageReference Include="NHibernate" Version="5.1.0" />
   </ItemGroup>
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.1-preview.{height}",
+  "version": "2.0.0-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
MySqlConnector 1.0 changes the primary namespace to `MySqlConnector`: mysql-net/MySqlConnector#824; this updates all relevant code.

This starts the discussion around updating MySqlConnector to 1.0, but doesn't need to be merged until it's out of beta.