### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ bugs in MySql.Data.
 
 Set `connection.driver_class` in your NHibernate session factory config to:
 
- - `connection.driver_class`: `NHibernate.Driver.MySqlConnectorDriver, NHibernate.Driver.MySqlConnector` 
+ - `connection.driver_class`: `NHibernate.Driver.MySqlConnector.MySqlConnectorDriver, NHibernate.Driver.MySqlConnector` 
  
 or use the Configure-by-code helper:
  


### PR DESCRIPTION
The namespace of the Driver class is wrong. It is currently 'NHibernate.Driver.MySqlConnectorDriver' instead of NHibernate.Driver.MySqlConnector.MySqlConnectorDriver.
This was causing the ISessionFactory startup to fail due to wrong Driver class specified.