### PR TITLE
docs: fix namespace of the driver in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ bugs in MySql.Data.
 
 Set `connection.driver_class` in your NHibernate session factory config to:
 
- - `connection.driver_class`: `NHibernate.Driver.MySqlConnectorDriver, NHibernate.Driver.MySqlConnector` 
+ - `connection.driver_class`: `NHibernate.Driver.MySqlConnector.MySqlConnectorDriver, NHibernate.Driver.MySqlConnector` 
  
 or use the Configure-by-code helper:
  


### PR DESCRIPTION
The namespace of the actual class is wrong, it should 'NHibernate.Driver.MySqlConnector.MySqlConnectorDriver' and not NHibernate.Driver.MySqlConnectorDriver

Fixes #5